### PR TITLE
Added some padding on the superscripts for footnotes

### DIFF
--- a/scss/app.scss
+++ b/scss/app.scss
@@ -280,6 +280,11 @@ article,
   .arabic {
     list-style-type: decimal;
   }
+  
+  .footnote-reference {
+    padding-left: .2em;
+    padding-right: .2em;
+  }
 
   footer {
     .tags {


### PR DESCRIPTION
You can see what they looks like here: https://alexgaynor.net/2011/jul/10/so-you-want-write-fast-python/