### PR TITLE
Attempt to fix the rendering of footnotes

### DIFF
--- a/scss/app.scss
+++ b/scss/app.scss
@@ -288,6 +288,10 @@ article,
     list-style-type: decimal;
   }
   
+  .footnote .label {
+      width: 2em;
+  }
+  
   .footnote-reference {
     padding-left: .2em;
     padding-right: .2em;


### PR DESCRIPTION
As you can see on https://alexgaynor.net/2016/mar/14/anatomy-of-a-crypto-vulnerability/ they render silly ATM